### PR TITLE
Updating audience restriction attribute

### DIFF
--- a/routes/saml.js
+++ b/routes/saml.js
@@ -17,7 +17,7 @@ exports.generate = function(req, res){
     key:               util.handleEmpty(req.body.cert.key),
     issuer:            'generalSSO',
     lifetimeInSeconds: 600,
-    audiences:         'zendesk.com',
+    audiences:         req.body.meta.destination,
     attributes:        req.body.attrs,
     nameIdentifier:    util.handleEmpty(req.body.nameid) || ' ' // permit empty string to simulate badly formatted NameID
   };


### PR DESCRIPTION
Per official public doc:
https://support.zendesk.com/hc/en-us/articles/203663676#topic_dzb_qx5_2v

> Zendesk enforces the AudienceRestriction attribute. The audience
> restriction must be subdomain.zendesk.com, where subdomain is your
> Zendesk subdomain.

Assuming that the `destination` under the meta section will filled with the following format `subdomain.zendesk.com`
